### PR TITLE
Fix path resolution for configs and cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,6 @@ hest = { git = "https://github.com/mahmoodlab/HEST.git", rev = "2c777630b1e8a74d
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.hatch.build.targets.wheel.force-include]
+"conf" = "seal/conf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,4 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel.force-include]
 "conf" = "seal/conf"
+"cache" = "seal/cache"

--- a/seal/models/encoder_factory.py
+++ b/seal/models/encoder_factory.py
@@ -14,7 +14,22 @@ import subprocess
 import shutil
 import os
 
+from pathlib import Path
+import argparse
 
+def find_config_yaml():
+    # 1. Check for local override first (preserves original behavior)
+    local_config = Path("conf/config.yaml")
+    if local_config.exists():
+        return str(local_config)
+    
+    # 2. Fall back to the bundled package config
+    package_config = Path(__file__).resolve().parent.parent / "conf" / "config.yaml"
+    if package_config.exists():
+        return str(package_config)
+    
+    # 3. Last resort fallback to avoid a silent failure
+    raise FileNotFoundError("Could not find config.yaml locally or in the installed package.")
 
 def get_constants(norm='imagenet'):
     IMAGENET_MEAN = [0.485, 0.456, 0.406]
@@ -781,7 +796,7 @@ def load_img_model_from_checkpoint(
     import argparse
     from seal.models.load_model import ModelMixin
     
-    default_config_path = argparse.Namespace(config='conf/config.yaml')
+    default_config_path = argparse.Namespace(config=find_config_yaml())
 
     if checkpoint_path is None:
         print(f"Warning: No image checkpoint provided for checkpoint_dir={checkpoint_dir}")
@@ -842,7 +857,7 @@ def load_gene_model_from_checkpoint(
     """
     from seal.models.load_model import ModelMixin
     
-    default_config_path = argparse.Namespace(config='conf/config.yaml')
+    default_config_path = argparse.Namespace(config=find_config_yaml())
     model_config = update_config(default_config_path)
     default_config = update_config(default_config_path)
     

--- a/seal/models/load_model.py
+++ b/seal/models/load_model.py
@@ -31,7 +31,7 @@ from seal.models.gene_model import GeneMLP, SCGPTEncoder, unfreeze_scgpt, ModelD
 import torch.nn as nn
 from seal.models.da_model import AdversarialDiscriminator
 from seal.models.encoder_factory import encoder_factory
-
+from pathlib import Path
 
 HF_API_KEY = os.getenv("HF_API_KEY")
 

--- a/seal/models/load_model.py
+++ b/seal/models/load_model.py
@@ -35,7 +35,17 @@ from seal.models.encoder_factory import encoder_factory
 
 HF_API_KEY = os.getenv("HF_API_KEY")
 
+def find_organ_ids():
+    rel_path = "cache/organ_ids.json"
+    id_file = Path(rel_path)
 
+    if not id_file.exists():
+        id_file = Path(__file__).resolve().parent.parent / rel_path
+        if not id_file.exists():
+            raise FileNotFoundError(f'Could not locate {rel_path} locally or in package.')
+    
+    with open(id_file, 'r') as f: 
+        return json.load(f) # You can return this directly without assigning it to a variable
 
 class ModelMixin(): 
     
@@ -533,8 +543,7 @@ class PatchRecEncoder(nn.Module):
         if self.use_adapter: 
             self.adapter = self.encoder.adapter
         
-        with open("cache/organ_ids.json", 'r') as f: 
-            organ_ids = json.load(f)
+        organ_ids = find_organ_ids()
         num_organs = len(organ_ids)
         
         if self.organ_token:


### PR DESCRIPTION
Hi MahmoodLab! SEAL is great work as usual, and thanks for the HuggingFace approval!

We noticed that the library relies on hard-coded relative paths (e.g., conf/config.yaml and cache/organ_ids.json). While this works perfectly when running scripts directly from the root of the cloned repository, it causes FileNotFoundErrors for users who install the package via pip and import it elsewhere.

This PR makes the library fully usable as an installed Python package while strictly preserving the existing behavior for local development and cluster deployments.

Changes Made:

Updated pyproject.toml: Configured the build system to include the conf/ and cache/ directories so they are bundled with the installed package.

Added Fallback Path Resolution: Refactored the file loading logic (e.g., in load_img_model_from_checkpoint and find_organ_ids) using pathlib. The code now dynamically checks for the files in two places:

* Local Working Directory First
* Package Directory Fallback

